### PR TITLE
Add metadata description and open graph tags

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -1,5 +1,13 @@
 {% extends "base.html" %}
 
+{% block metadata %}
+	<meta name="description" content="{% if article.description %}{{ article.description }}{% else %}{{ BIO }}{% endif %}">
+	<meta property="og:description" content="{% if article.description %}{{ article.description }}{% else %}{{ BIO }}{% endif %}">
+	<meta property="og:title" content="{{ article.title }}" />
+	<meta property="og:type" content="article" />
+	<meta property="og:url" content="{{ SITEURL }}/{{ article.url }}" />
+{% endblock %}
+
 {% block content %}
 <div class="post">
 	<h1 class="post-title">{{ article.title }}</h1>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,9 +1,19 @@
 <!DOCTYPE html>
-<html lang="{{ DEFAULT_LANG }}">
+<html lang="{{ DEFAULT_LANG }}" prefix="og: http://ogp.me/ns#">
 	<head>
 		<link href="http://gmpg.org/xfn/11" rel="profile">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta http-equiv="content-type" content="text/html; charset=utf-8">
+
+		<!-- Metadata -->
+		{% block metadata %}
+			<meta name="description" content="{{ BIO }}" />
+			<meta property="og:description" content="{{ BIO }}" />
+			<meta property="og:title" content="{{ SITENAME }}{% if SITESUBTITLE %} | {{ SITESUBTITLE }}{% endif %}" />
+			<meta property="og:type" content="website" />
+			<meta property="og:url" content="{{ SITEURL }}" />
+		{% endblock %}
+		<meta property="og:image" content="{{ SITEURL }}/images/{{ PROFILE_IMAGE }}" />
 
 		<!-- Enable responsiveness on mobile devices-->
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">


### PR DESCRIPTION
Two related things in one commit (not the best practice, I know):
- A description that are often presented on search engines results using a new `article.description` field. I decided not to use the already exists `article.summary` field as for me it feels that they have different porpuses. I want the description to be < 160 characters, but don't want short summaries with zero formating and no images on my index page.
- Open graph tags, so shares on social media will appear properly: a card with an image and description.

I will love to hear what you think and change the PR accordingly.
Thanks!