### PR TITLE
Update font-awesome to 5.13.0 and support kit.fontawesome.com

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -27,7 +27,11 @@
 		<link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/poole.css" />
 		<link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/hyde.css" />
 		<link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/syntax.css" />
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+		{% if FONT_AWESOME %}
+			<script src="https://kit.fontawesome.com/{{ FONT_AWESOME }}.js" crossorigin="anonymous"></script>
+		{% else %}
+			<script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js" crossorigin="anonymous"></script>
+		{% endif %}
 
 		<!-- RSS -->
 		<link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -16,16 +16,16 @@
 			{% for name, link in SOCIAL %}
 				{% if name == 'email' %}
 					<a class="sidebar-nav-item" href="mailto:{{ link }}">
-						<i class="fa fa-envelope"></i>
+						<i class="fas fa-envelope"></i>
 					</a>
 				{% else %}
 					<a class="sidebar-nav-item" href="{{ link }}">
-						<i class="fa fa-{{ name }}"></i>
+						<i class="fab fa-{{ name }}"></i>
 					</a>
 				{% endif %}
 			{% endfor %}
 			<a class="sidebar-nav-item" href="{{ FEED_ALL_RSS }}">
-				<i class="fa fa-feed"></i>
+				<i class="fas fa-rss"></i>
 			</a>
 		</nav>
 	</div>


### PR DESCRIPTION
This PR adds support for font-awesome version 5+ and checks the variable `FONT_AWESOME` so that https://fontawesome.com/kits is supported (but falls back to https://cdnjs.com/libraries/font-awesome otherwise).