### PR TITLE
Support Academicons

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -27,6 +27,7 @@
 		<link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/poole.css" />
 		<link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/hyde.css" />
 		<link rel="stylesheet" href="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/css/syntax.css" />
+		<link rel="stylesheet" href="https://cdn.rawgit.com/jpswalsh/academicons/master/css/academicons.min.css">
 		{% if FONT_AWESOME %}
 			<script src="https://kit.fontawesome.com/{{ FONT_AWESOME }}.js" crossorigin="anonymous"></script>
 		{% else %}

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -18,6 +18,17 @@
 					<a class="sidebar-nav-item" href="mailto:{{ link }}">
 						<i class="fas fa-envelope"></i>
 					</a>
+				{% elif name in ['academia', 'acclaim', 'acm', 'acmdl', 'ads', 'arxiv',
+						 'biorxiv', 'ceur', 'coursera', 'cv', 'dataverse',
+						 'dblp', 'depsy', 'doi', 'dryad', 'figshare',
+						 'google-scholar', 'ideas-repec', 'ieee', 'impactstory',
+						 'inspire', 'lattes', 'mathoverflow', 'open-access',
+						 'osf', 'overleaf', 'philpapers', 'piazza', 'publons',
+						 'pubmed', 'researcherid', 'scirate', 'semantic-scholar',
+						 'springer', 'zotero'] %}
+					<a class="sidebar-nav-item" href="{{ link }}">
+						<i class="ai ai-{{ name }}"></i>
+					</a>
 				{% else %}
 					<a class="sidebar-nav-item" href="{{ link }}">
 						<i class="fab fa-{{ name }}"></i>


### PR DESCRIPTION
This PR extends the functionality of font-awesome with icons relevant to the academic community (this includes an icon for Lattes curricula) as per https://jpswalsh.github.io/academicons/.

The template automatically detects the name of the icon and appropriately inserts the correct one. A list of supported academic icons can be found [here](https://jpswalsh.github.io/academicons/).