### PR TITLE
Replace Google Analytics fragment to use Google Analytics 4

### DIFF
--- a/templates/fragments/google_analytics.html
+++ b/templates/fragments/google_analytics.html
@@ -1,11 +1,11 @@
 {% if GOOGLE_ANALYTICS %}
-<script type="text/javascript">
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-ga('create', '{{ GOOGLE_ANALYTICS }}', '{{ GA_COOKIE_DOMAIN if GA_COOKIE_DOMAIN else 'auto' }}');
-ga('send', 'pageview');
+  gtag('config', '{{ GOOGLE_ANALYTICS }}');
 </script>
 {% endif %}


### PR DESCRIPTION
Fixes #22 

The current script supports the old version of Google Analytics called "Universal Analytics".
We want to support the new Google Analytics 4 service.
After the change, **only** the new version of Google Analytics 4 will be supported.
I could use a conditional flow to support both versions but I'm not in favor of this because it's better to go forward with the new service and keep the `GOOGLE_ANALYTICS` setting untouched.

**Changes**
- Replace the script in `fragments/google_analytics.html` to support the new Google Analytics 4 service.

  
_Reference_
You can read more about Google Analytics and how to migrate [here](https://support.google.com/analytics/answer/10089681?hl=en&ref_topic=12154439).