### PR TITLE
Fix link to homepage in sidebar

### DIFF
--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -3,7 +3,7 @@
 		<div class="sidebar-about">
 
 			<h1>
-				<a href="/">
+				<a href="{{ SITEURL }}/">
 					<img class="profile-picture" src="{{ SITEURL }}/images/{{ PROFILE_IMAGE }}">
 					{{ SITENAME }}
 				</a>


### PR DESCRIPTION
This fixes an issue when the website is deployed to a subdirectory of the web server (e.g., `SITEURL` is set to a value like `https://example.com/john.doe/`).