### PR TITLE
fix: fixed handling of article image metadata in articles

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -6,6 +6,9 @@
 	<meta property="og:title" content="{{ article.title }}" />
 	<meta property="og:type" content="article" />
 	<meta property="og:url" content="{{ SITEURL }}/{{ article.url }}" />
+    {% if article.image %}
+        <meta property="og:image" content="{{ article.image }}" />
+    {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,8 +12,8 @@
 			<meta property="og:title" content="{{ SITENAME }}{% if SITESUBTITLE %} - {{ SITESUBTITLE }}{% endif %}" />
 			<meta property="og:type" content="website" />
 			<meta property="og:url" content="{{ SITEURL }}" />
+            <meta property="og:image" content="{{ SITEURL }}/images/{{ PROFILE_IMAGE }}" />
 		{% endblock %}
-		<meta property="og:image" content="{{ SITEURL }}/images/{{ PROFILE_IMAGE }}" />
 
 		<!-- Enable responsiveness on mobile devices-->
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">


### PR DESCRIPTION
## Description

In Pelican articles you can include image metadata. Please see how pelican-seo plugin handles article image metadata: https://github.com/pelican-plugins/seo?tab=readme-ov-file#article-schema

This template does not take this into account and always uses the PROFILE_IMAGE. This is not correct and negates that image metadata.

So I wrote a fix for this: in the article template the article.image is now added if it exists.

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #26 
